### PR TITLE
CI: publish p2 repo to GitHub Pages

### DIFF
--- a/.github/workflows/publish-p2.yml
+++ b/.github/workflows/publish-p2.yml
@@ -1,0 +1,54 @@
+name: Build and publish p2 repo
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build bundle and p2 repo
+        working-directory: com.philomathery.pdf.certificate
+        run: mvn -B clean package
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p p2
+          cp -R com.philomathery.pdf.certificate/target/p2-repo/* p2/
+          touch p2/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: p2
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
CI: publish p2 repo to GitHub Pages on master builds

- Build with Java 21 and Maven
- Upload target/p2-repo as Pages artifact
- Add .nojekyll to avoid Jekyll filtering