### PR TITLE
CI/Publish: add GitHub Packages deployment

### DIFF
--- a/.github/workflows/deploy-github-packages.yml
+++ b/.github/workflows/deploy-github-packages.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Configure Maven for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Deploy artifact to GitHub Packages
+        working-directory: com.philomathery.pdf.certificate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B -DskipTests deploy

--- a/com.philomathery.pdf.certificate/export.bndrun
+++ b/com.philomathery.pdf.certificate/export.bndrun
@@ -3,9 +3,9 @@
 -runrequires: \
   osgi.identity;filter:='(osgi.identity=com.philomathery.pdf.certificate)'
 
--export: true
--exporter: p2
--output: ${project}/target/p2-repo
+# Enable p2 exporter and define export target
+-plugin: aQute.bnd.exporter.p2.P2Exporter
+-export: pcg;type=p2;name=pcg;out=${project}/target/p2-repo
 
 # Let bnd resolve dependencies automatically
 -resolve: auto

--- a/com.philomathery.pdf.certificate/pom.xml
+++ b/com.philomathery.pdf.certificate/pom.xml
@@ -94,4 +94,12 @@
       <version>2.9</version>
     </dependency>
   </dependencies>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/seemikehack/pcg</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
CI/Publish: add GitHub Packages deployment

- distributionManagement to maven.pkg.github.com/seemikehack/pcg
- Deploy workflow on v* tags using GITHUB_TOKEN